### PR TITLE
Removed CSS setting that blocked RTL pages

### DIFF
--- a/bookmarklets/responsive/responsive.css
+++ b/bookmarklets/responsive/responsive.css
@@ -24,7 +24,6 @@ audio, video {
 	width: auto !important;
 	position: static !important;
 	min-width: 0 !important;
-	text-align: left !important;
 	margin: 0 auto !important;
 	transform: none !important;
 }


### PR DESCRIPTION
text-align is by default "left if direction is ltr, and right if direction is rtl", so why touch it?

When you make a page responsive it's not about changing text alignment.